### PR TITLE
SNI support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,17 +117,8 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
     </dependency>
-<!--    for debugging only-->
-<!--    <dependency>-->
-<!--      <groupId>org.bouncycastle</groupId>-->
-<!--      <artifactId>bcprov-debug-jdk15on</artifactId>-->
-<!--      <version>1.68</version>-->
-<!--    </dependency>-->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <!--    for debugging only (self compiled )-->
-<!--      <artifactId>bcpkix-debug-jdk15on</artifactId>-->
-<!--      <version>1.69b02</version>-->
       <artifactId>bcpkix-jdk15to18</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,13 +10,13 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <netty.version>4.1.54.Final</netty.version>
+    <netty.version>4.1.60.Final</netty.version>
     <tcnative.artifactId>netty-tcnative-boringssl-static</tcnative.artifactId>
     <tcnative.version>2.0.35.Final</tcnative.version>
     <tcnative.classifier>${os.detected.classifier}</tcnative.classifier>
     <guava.version>30.0-jre</guava.version>
     <logback.version>1.2.1</logback.version>
-    <bouncycastle.version>1.54</bouncycastle.version>
+    <bouncycastle.version>1.68</bouncycastle.version>
     <commons-cli.version>1.3.1</commons-cli.version>
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.18.1</assertj.version>
@@ -117,9 +117,18 @@
       <artifactId>logback-classic</artifactId>
       <version>${logback.version}</version>
     </dependency>
+<!--    for debugging only-->
+<!--    <dependency>-->
+<!--      <groupId>org.bouncycastle</groupId>-->
+<!--      <artifactId>bcprov-debug-jdk15on</artifactId>-->
+<!--      <version>1.68</version>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <!--    for debugging only (self compiled )-->
+<!--      <artifactId>bcpkix-debug-jdk15on</artifactId>-->
+<!--      <version>1.69b02</version>-->
+      <artifactId>bcpkix-jdk15to18</artifactId>
       <version>${bouncycastle.version}</version>
     </dependency>
     <dependency>

--- a/src/main/java/com/github/chhsiaoninety/nitmproxy/ConnectionContext.java
+++ b/src/main/java/com/github/chhsiaoninety/nitmproxy/ConnectionContext.java
@@ -106,6 +106,7 @@ public class ConnectionContext
         if (serverChannel == null) {
             tlsCtx.protocols(fromCtx.executor().newPromise());
             tlsCtx.protocol(fromCtx.executor().newPromise());
+            tlsCtx.hostname(fromCtx.executor().newPromise());
         }
         if (serverChannel != null && (!serverAddr.equals(address) || !serverChannel.isActive())) {
             serverChannel.close();

--- a/src/main/java/com/github/chhsiaoninety/nitmproxy/TlsContext.java
+++ b/src/main/java/com/github/chhsiaoninety/nitmproxy/TlsContext.java
@@ -9,6 +9,7 @@ import io.netty.util.concurrent.Promise;
 public class TlsContext {
   private Promise<List<String>> protocols;
   private Promise<String> protocol;
+  private Promise<String> hostname;
 
   public TlsContext protocols(Promise<List<String>> protocols) {
     this.protocols = protocols;
@@ -51,6 +52,27 @@ public class TlsContext {
 
   public Promise<String> protocolPromise() {
     return protocol;
+  }
+
+  public TlsContext hostname(Promise<String> hostname) {
+    this.hostname = hostname;
+    return this;
+  }
+
+  /**
+   * Get the extracted hostname.
+   *
+   * @return the hostname
+   */
+  public String hostname() {
+    if (!hostname.isDone()) {
+      throw new TlsException("hostname not extracted before accessing");
+    }
+    return hostname.getNow();
+  }
+
+  public Promise<String> hostnamePromise() {
+    return hostname;
   }
 
   public boolean isNegotiated() {

--- a/src/main/java/com/github/chhsiaoninety/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
+++ b/src/main/java/com/github/chhsiaoninety/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
@@ -38,6 +38,11 @@ public class TlsBackendHandler extends ChannelDuplexHandler {
   }
 
   @Override
+  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+    super.userEventTriggered(ctx, evt);
+  }
+
+  @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     LOGGER.debug("{} : handlerAdded", connectionContext);
 


### PR DESCRIPTION
thanks a lot for your awesome project, this is really helpful. I had an issue when connection from an Android application using a SOCKS connection. The hostname has been missing and just the server destination's IP address was visible, hence the MITM certificate CNs were not matching the actual domain but was using the IP address. I added support for server name indication extraction. I have zero experience with netty so my patch might have issues. Please check and integrate it.

I also updated the netty and BC version.