### PR TITLE
Fix for null ALPN of Conscrypt TLS implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.18.1</assertj.version>
     <mockito.version>3.6.28</mockito.version>
-    <jetty.alpnAgent.version>2.0.6</jetty.alpnAgent.version>
+    <jetty.alpnAgent.version>2.0.10</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}</argLine.alpnAgent>
     <argLine.leak>-D_</argLine.leak>
@@ -49,6 +49,34 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>unpack</id>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>io.netty</groupId>
+                  <artifactId>netty-all</artifactId>
+                  <version>${netty.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                  <excludes>
+                    **/JdkAlpnSslUtils.class
+                  </excludes>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>kr.motd.maven</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.0.0.Final</version>
@@ -65,6 +93,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
         <configuration>
           <argLine>${argLine.leak} ${argLine.alpnAgent} ${argLine.coverage}</argLine>
         </configuration>
@@ -115,11 +144,6 @@
   <dependencies>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-all</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
       <artifactId>${tcnative.artifactId}</artifactId>
       <version>${tcnative.version}</version>
       <classifier>${tcnative.classifier}</classifier>
@@ -160,6 +184,12 @@
       <artifactId>mockito-core</artifactId>
       <version>${mockito.version}</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mortbay.jetty.alpn</groupId>
+      <artifactId>jetty-alpn-agent</artifactId>
+      <version>${jetty.alpnAgent.version}</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/AbstractAlpnHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/AbstractAlpnHandler.java
@@ -119,7 +119,7 @@ public abstract class AbstractAlpnHandler<T> extends SslClientHelloHandler<T> {
   }
 
   protected abstract void onLookupComplete(ChannelHandlerContext ctx,
-      List<String> hostname, Future<T> future) throws Exception;
+      List<String> protocols, Future<T> future) throws Exception;
 
   private static void fireAlpnCompletionEvent(ChannelHandlerContext ctx, List<String> protocols,
       Future<?> future) {

--- a/src/main/java/io/netty/handler/ssl/JdkAlpnSslUtils.java
+++ b/src/main/java/io/netty/handler/ssl/JdkAlpnSslUtils.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2017 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+package io.netty.handler.ssl;
+
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.List;
+import java.util.function.BiFunction;
+
+import io.netty.util.internal.EmptyArrays;
+import io.netty.util.internal.PlatformDependent;
+import io.netty.util.internal.StringUtil;
+import io.netty.util.internal.SuppressJava6Requirement;
+import io.netty.util.internal.logging.InternalLogger;
+import io.netty.util.internal.logging.InternalLoggerFactory;
+
+@SuppressJava6Requirement(reason = "Usage guarded by java version check")
+class JdkAlpnSslUtils {
+    private static final InternalLogger logger = InternalLoggerFactory.getInstance(JdkAlpnSslUtils.class);
+    private static final Method SET_APPLICATION_PROTOCOLS;
+    private static final Method GET_APPLICATION_PROTOCOL;
+    private static final Method GET_HANDSHAKE_APPLICATION_PROTOCOL;
+    private static final Method SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
+    private static final Method GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR;
+
+    static {
+        Method getHandshakeApplicationProtocol;
+        Method getApplicationProtocol;
+        Method setApplicationProtocols;
+        Method setHandshakeApplicationProtocolSelector;
+        Method getHandshakeApplicationProtocolSelector;
+
+        try {
+            SSLContext context = SSLContext.getInstance(JdkSslContext.PROTOCOL);
+            context.init(null, null, null);
+            SSLEngine engine = context.createSSLEngine();
+            getHandshakeApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return SSLEngine.class.getMethod("getHandshakeApplicationProtocol");
+                }
+            });
+            getHandshakeApplicationProtocol.invoke(engine);
+            getApplicationProtocol = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return SSLEngine.class.getMethod("getApplicationProtocol");
+                }
+            });
+            getApplicationProtocol.invoke(engine);
+
+            setApplicationProtocols = AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return SSLParameters.class.getMethod("setApplicationProtocols", String[].class);
+                }
+            });
+            setApplicationProtocols.invoke(engine.getSSLParameters(), new Object[]{EmptyArrays.EMPTY_STRINGS});
+
+            setHandshakeApplicationProtocolSelector =
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return SSLEngine.class.getMethod("setHandshakeApplicationProtocolSelector", BiFunction.class);
+                }
+            });
+            setHandshakeApplicationProtocolSelector.invoke(engine, new BiFunction<SSLEngine, List<String>, String>() {
+                @Override
+                public String apply(SSLEngine sslEngine, List<String> strings) {
+                    return null;
+                }
+            });
+
+            getHandshakeApplicationProtocolSelector =
+                    AccessController.doPrivileged(new PrivilegedExceptionAction<Method>() {
+                @Override
+                public Method run() throws Exception {
+                    return SSLEngine.class.getMethod("getHandshakeApplicationProtocolSelector");
+                }
+            });
+            getHandshakeApplicationProtocolSelector.invoke(engine);
+        } catch (Throwable t) {
+            int version = PlatformDependent.javaVersion();
+            if (version >= 9) {
+                // We only log when run on java9+ as this is expected on some earlier java8 versions
+                logger.error("Unable to initialize JdkAlpnSslUtils, but the detected java version was: {}", version, t);
+            }
+            getHandshakeApplicationProtocol = null;
+            getApplicationProtocol = null;
+            setApplicationProtocols = null;
+            setHandshakeApplicationProtocolSelector = null;
+            getHandshakeApplicationProtocolSelector = null;
+        }
+        GET_HANDSHAKE_APPLICATION_PROTOCOL = getHandshakeApplicationProtocol;
+        GET_APPLICATION_PROTOCOL = getApplicationProtocol;
+        SET_APPLICATION_PROTOCOLS = setApplicationProtocols;
+        SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR = setHandshakeApplicationProtocolSelector;
+        GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR = getHandshakeApplicationProtocolSelector;
+    }
+
+    protected JdkAlpnSslUtils() {
+    }
+
+    static boolean supportsAlpn() {
+        return GET_APPLICATION_PROTOCOL != null;
+    }
+
+    static String getApplicationProtocol(SSLEngine sslEngine) {
+        try {
+            String protocol = (String) GET_APPLICATION_PROTOCOL.invoke(sslEngine);
+            if (protocol == null) {
+                return StringUtil.EMPTY_STRING;
+            }
+            return protocol;
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static String getHandshakeApplicationProtocol(SSLEngine sslEngine) {
+        try {
+            return (String) GET_HANDSHAKE_APPLICATION_PROTOCOL.invoke(sslEngine);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    static void setApplicationProtocols(SSLEngine engine, List<String> supportedProtocols) {
+        SSLParameters parameters = engine.getSSLParameters();
+
+        String[] protocolArray = supportedProtocols.toArray(EmptyArrays.EMPTY_STRINGS);
+        try {
+            SET_APPLICATION_PROTOCOLS.invoke(parameters, new Object[]{protocolArray});
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+        engine.setSSLParameters(parameters);
+    }
+
+    static void setHandshakeApplicationProtocolSelector(
+            SSLEngine engine, BiFunction<SSLEngine, List<String>, String> selector) {
+        try {
+            SET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine, selector);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    static BiFunction<SSLEngine, List<String>, String> getHandshakeApplicationProtocolSelector(SSLEngine engine) {
+        try {
+            return (BiFunction<SSLEngine, List<String>, String>)
+                    GET_HANDSHAKE_APPLICATION_PROTOCOL_SELECTOR.invoke(engine);
+        } catch (UnsupportedOperationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+}


### PR DESCRIPTION
The current solution did not work for pages not returning an ALPN extension. The error is related to a [conscrypt problem](https://github.com/google/conscrypt/issues/1003). Java requires that an empty string is returned if no ALPN is set, `null` is only allowed if the information is not yet available. An example domain where this happens is www.spiegel.de
I have submitted a patch to conscrypt, but because I'm targeting Android this will never be fixed in already produced phones not receiving firmware updates anymore. The only way is a monkey patch, hence I'm using a patched class from netty which is reachable to apply the patch. I extract netty and add my patched class to it.
