### PR TITLE
HTTPs detection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <junit.version>4.13.1</junit.version>
     <assertj.version>3.18.1</assertj.version>
     <mockito.version>3.6.28</mockito.version>
-    <jetty.alpnAgent.version>2.0.6</jetty.alpnAgent.version>
+    <jetty.alpnAgent.version>2.0.10</jetty.alpnAgent.version>
     <jetty.alpnAgent.path>"${settings.localRepository}"/org/mortbay/jetty/alpn/jetty-alpn-agent/${jetty.alpnAgent.version}/jetty-alpn-agent-${jetty.alpnAgent.version}.jar</jetty.alpnAgent.path>
     <argLine.alpnAgent>-javaagent:${jetty.alpnAgent.path}</argLine.alpnAgent>
     <argLine.leak>-D_</argLine.leak>
@@ -113,6 +113,12 @@
     </profile>
   </profiles>
   <dependencies>
+    <dependency>
+      <groupId>org.mortbay.jetty.alpn</groupId>
+      <artifactId>jetty-alpn-agent</artifactId>
+      <version>${jetty.alpnAgent.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>

--- a/src/main/java/com/github/chhsiao90/nitmproxy/TlsContext.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/TlsContext.java
@@ -2,15 +2,31 @@ package com.github.chhsiao90.nitmproxy;
 
 import com.github.chhsiao90.nitmproxy.exception.TlsException;
 
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
 import java.util.List;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLEngine;
 
 import io.netty.util.concurrent.Promise;
 
 public class TlsContext {
 
-  private boolean plain;
+  private boolean enabled = true;
+  private final static boolean SUPPORT_ALPN;
   private Promise<List<String>> protocols;
   private Promise<String> protocol;
+  private final static List<String> TLS_PROTOCOLS;
+
+  static {
+    SUPPORT_ALPN = Arrays.stream(SSLEngine.class.getDeclaredMethods()).anyMatch(m -> m.getName().equals("getApplicationProtocol"));
+    try {
+      TLS_PROTOCOLS = Arrays.asList(SSLContext.getDefault().createSSLEngine().getSupportedProtocols());
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException("Could not init default SSLContext.", e);
+    }
+  }
 
   public TlsContext protocols(Promise<List<String>> protocols) {
     this.protocols = protocols;
@@ -59,11 +75,19 @@ public class TlsContext {
     return protocol.isDone();
   }
 
-  public boolean isPlain() {
-    return plain;
+  public boolean isEnabled() {
+    return enabled;
   }
 
-  public void setPlain(boolean plain) {
-    this.plain = plain;
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public boolean isSupportAlpn() {
+    return SUPPORT_ALPN;
+  }
+
+  public List<String> getTlsProtocols() {
+    return TLS_PROTOCOLS;
   }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/TlsContext.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/TlsContext.java
@@ -7,6 +7,8 @@ import java.util.List;
 import io.netty.util.concurrent.Promise;
 
 public class TlsContext {
+
+  private boolean plain;
   private Promise<List<String>> protocols;
   private Promise<String> protocol;
 
@@ -55,5 +57,13 @@ public class TlsContext {
 
   public boolean isNegotiated() {
     return protocol.isDone();
+  }
+
+  public boolean isPlain() {
+    return plain;
+  }
+
+  public void setPlain(boolean plain) {
+    this.plain = plain;
   }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
@@ -22,6 +22,7 @@ import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.handler.ssl.ApplicationProtocolNegotiationHandler;
 import io.netty.handler.ssl.SslHandler;
 import io.netty.util.ReferenceCountUtil;
+
 import javax.net.ssl.SSLException;
 
 public class TlsBackendHandler extends ChannelDuplexHandler {
@@ -48,7 +49,11 @@ public class TlsBackendHandler extends ChannelDuplexHandler {
 
     connectionContext.tlsCtx().protocolsPromise().addListener(future -> {
       if (future.isSuccess()) {
-        configSsl(ctx);
+        if (connectionContext.tlsCtx().isPlain()) {
+          configHttp1(ctx);
+        } else {
+          configSsl(ctx);
+        }
       } else {
         ctx.close();
       }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/tls/TlsUtil.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/tls/TlsUtil.java
@@ -41,8 +41,11 @@ public class TlsUtil {
     public static SslContext ctxForClient(ConnectionContext context) throws SSLException {
         SslContextBuilder builder = SslContextBuilder
             .forClient()
-            .protocols("TLSv1.3", "TLSv1.2")
-            .applicationProtocolConfig(applicationProtocolConfig(context.tlsCtx()));
+            .protocols(context.tlsCtx().getTlsProtocols());
+            builder.applicationProtocolConfig(
+                    context.tlsCtx().isSupportAlpn() ?
+                            applicationProtocolConfig(context.tlsCtx()):
+                            ApplicationProtocolConfig.DISABLED);
         if (context.config().isInsecure()) {
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         } else if (TRUST_MANAGER_FACTORY != null) {
@@ -58,8 +61,10 @@ public class TlsUtil {
             certFile, keyFile, context.getServerAddr().getHost());
         return SslContextBuilder
             .forServer(certificate.getKeyPair().getPrivate(), certificate.getChain())
-            .protocols("TLSv1.3", "TLSv1.2")
-            .applicationProtocolConfig(applicationProtocolConfig(context.tlsCtx()))
+            .protocols(context.tlsCtx().getTlsProtocols())
+            .applicationProtocolConfig(context.tlsCtx().isSupportAlpn() ?
+                    applicationProtocolConfig(context.tlsCtx()):
+                    ApplicationProtocolConfig.DISABLED)
             .build();
     }
 


### PR DESCRIPTION
I have checked some web pages using different ports for HTTPs. I added a DetectSslHandler to see if a ClientHello was received. But the code has problems to work with non HTTPs sides. The HTTP1BackendHandler is not triggered. Can you please have a look? Removing all handlers and set `configHttp1(ctx);` does not seem to be enough. I somehow the already read data swallow and netty cannot handle this to feed back this to the new handler?

~~~java
  if (!future.getNow()) {
          connectionContext.tlsCtx().setPlain(true);
          connectionContext.tlsCtx().protocolsPromise().setSuccess(Collections.singletonList(ApplicationProtocolNames.HTTP_1_1));
          ctx.pipeline().remove(DetectSslHandler.class);
          ctx.pipeline().remove(AlpnNegotiateHandler.class);
          ctx.pipeline().remove(SniExtractorHandler.class);
          configHttp1(ctx);
        } else {
~~~