### PR TITLE
added KeyManagerFactory as parameter

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -3,6 +3,7 @@ package com.github.chhsiao90.nitmproxy;
 import com.github.chhsiao90.nitmproxy.enums.ProxyMode;
 import com.google.common.base.Joiner;
 
+import javax.net.ssl.KeyManagerFactory;
 import java.util.Arrays;
 import java.util.List;
 
@@ -17,6 +18,7 @@ public class NitmProxyConfig {
     private String certFile;
     private String keyFile;
     private boolean insecure;
+    private KeyManagerFactory clientKeyManagerFactory;
 
     private int maxContentLength;
 
@@ -99,6 +101,14 @@ public class NitmProxyConfig {
         this.maxContentLength = maxContentLength;
     }
 
+    public KeyManagerFactory getClientKeyManagerFactory() {
+        return clientKeyManagerFactory;
+    }
+
+    public void setClientKeyManagerFactory(KeyManagerFactory clientKeyManagerFactory) {
+        this.clientKeyManagerFactory = clientKeyManagerFactory;
+    }
+
     @Override
     public String toString() {
         List<String> properties = Arrays.asList(
@@ -109,6 +119,7 @@ public class NitmProxyConfig {
                 String.format("certFile=%s", certFile),
                 String.format("keyFile=%s", keyFile),
                 String.format("insecure=%b", insecure),
+                String.format("keyManagerFactory=%b", clientKeyManagerFactory),
                 String.format("maxContentLength=%d", maxContentLength));
         return String.format("NitmProxyConfig%n%s",
                              Joiner.on(System.lineSeparator()).join(properties));

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
@@ -39,11 +39,6 @@ public class TlsBackendHandler extends ChannelDuplexHandler {
   }
 
   @Override
-  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-    super.userEventTriggered(ctx, evt);
-  }
-
-  @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     LOGGER.debug("{} : handlerAdded", connectionContext);
 

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
@@ -41,11 +41,6 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
 
 
   @Override
-  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
-    super.userEventTriggered(ctx, evt);
-  }
-
-  @Override
   public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
     LOGGER.debug("{} : handlerAdded", connectionContext);
     ctx.pipeline()

--- a/src/main/java/com/github/chhsiao90/nitmproxy/tls/TlsUtil.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/tls/TlsUtil.java
@@ -46,6 +46,9 @@ public class TlsUtil {
                     context.tlsCtx().isSupportAlpn() ?
                             applicationProtocolConfig(context.tlsCtx()):
                             ApplicationProtocolConfig.DISABLED);
+        if (context.config().getClientKeyManagerFactory() != null) {
+            builder.keyManager(context.config().getClientKeyManagerFactory());
+        }
         if (context.config().isInsecure()) {
             builder.trustManager(InsecureTrustManagerFactory.INSTANCE);
         } else if (TRUST_MANAGER_FACTORY != null) {


### PR DESCRIPTION
To be able to support TLS client authentication it is necessary to have a way to set a KeyManagerFactory.

I also removed two `userEventTriggered` methods erroneously committed with an earlier commit.