### PR TITLE
Support for external data loggers

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -6,6 +6,7 @@ import com.google.common.base.Joiner;
 import javax.net.ssl.KeyManagerFactory;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
 public class NitmProxyConfig {
     private ProxyMode proxyMode;
@@ -21,6 +22,9 @@ public class NitmProxyConfig {
     private KeyManagerFactory clientKeyManagerFactory;
 
     private int maxContentLength;
+
+    private Consumer<byte[]> requestLogger;
+    private Consumer<byte[]> responseLogger;
 
     // Default values
     public NitmProxyConfig() {
@@ -107,6 +111,22 @@ public class NitmProxyConfig {
 
     public void setClientKeyManagerFactory(KeyManagerFactory clientKeyManagerFactory) {
         this.clientKeyManagerFactory = clientKeyManagerFactory;
+    }
+
+    public Consumer<byte[]> getRequestLogger() {
+        return requestLogger;
+    }
+
+    public void setRequestLogger(Consumer<byte[]> requestLogger) {
+        this.requestLogger = requestLogger;
+    }
+
+    public Consumer<byte[]> getResponseLogger() {
+        return responseLogger;
+    }
+
+    public void setResponseLogger(Consumer<byte[]> responseLogger) {
+        this.responseLogger = responseLogger;
     }
 
     @Override


### PR DESCRIPTION
This patch allows to use external loggers. This is the preparation to export the MITM clear text data to different programs. Not sure if I mentioned it, but the goal is to combine this with a VPNService in Android allowing to intercept network traffic. The target project is [PCAPdroid](https://github.com/emanuele-f/PCAPdroid). The data is then exported a PCAP file and can be used with wireshark to analyze the network traffic.