### PR TITLE
HTTP only fix, removing explicit ports for HTTPS

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/ConnectionContext.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/ConnectionContext.java
@@ -94,10 +94,6 @@ public class ConnectionContext
         }
     }
 
-    public boolean isHttps() {
-        return master.config().getHttpsPorts().contains(serverAddr.getPort());
-    }
-
     public boolean connected() {
         return serverChannel != null;
     }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -14,7 +14,6 @@ public class NitmProxyConfig {
     private int port;
 
     // TLS related
-    private List<Integer> httpsPorts;
     private String certFile;
     private String keyFile;
     private boolean insecure;
@@ -29,7 +28,6 @@ public class NitmProxyConfig {
         host = "127.0.0.1";
         port = 8080;
 
-        httpsPorts = Arrays.asList(443, 8443);
         certFile = "server.pem";
         keyFile = "key.pem";
         insecure = false;
@@ -59,14 +57,6 @@ public class NitmProxyConfig {
 
     public void setPort(int port) {
         this.port = port;
-    }
-
-    public List<Integer> getHttpsPorts() {
-        return httpsPorts;
-    }
-
-    public void setHttpsPorts(List<Integer> httpsPorts) {
-        this.httpsPorts = httpsPorts;
     }
 
     public String getCertFile() {
@@ -115,7 +105,6 @@ public class NitmProxyConfig {
                 String.format("proxyMode=%s", proxyMode),
                 String.format("host=%s", host),
                 String.format("port=%s", port),
-                String.format("httpsPorts=%s", httpsPorts),
                 String.format("certFile=%s", certFile),
                 String.format("keyFile=%s", keyFile),
                 String.format("insecure=%b", insecure),

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
@@ -112,12 +112,12 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
         if (!future.getNow()) {
           connectionContext.tlsCtx().setEnabled(false);
           connectionContext.tlsCtx().protocolsPromise().setSuccess(Collections.singletonList(ApplicationProtocolNames.HTTP_1_1));
+          configHttp1(tlsCtx);
           ctx.pipeline().remove(SniExtractorHandler.class);
           if (connectionContext.tlsCtx().isSupportAlpn()) {
             ctx.pipeline().remove(AlpnNegotiateHandler.class);
           }
           ctx.pipeline().remove(ctx.name());
-          configHttp1(tlsCtx);
         } else {
           ctx.pipeline().remove(ctx.name());
         }


### PR DESCRIPTION
This removes all fixed HTTPs checks and supports plain HTTP.