### PR TITLE
Support non http protocols

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/ConnectionContext.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/ConnectionContext.java
@@ -11,6 +11,7 @@ import io.netty.channel.ChannelInitializer;
 import static java.lang.String.*;
 
 public class ConnectionContext {
+
     private NitmProxyMaster master;
     private HandlerProvider provider;
 

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -1,14 +1,16 @@
 package com.github.chhsiao90.nitmproxy;
 
 import com.github.chhsiao90.nitmproxy.enums.ProxyMode;
+import com.github.chhsiao90.nitmproxy.handler.protocol.ProtocolDetector;
+import com.github.chhsiao90.nitmproxy.handler.protocol.http1.Http1ProtocolDetector;
 import com.github.chhsiao90.nitmproxy.listener.HttpListener;
 import com.google.common.base.Joiner;
 
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
-
 import java.security.Provider;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import static java.lang.String.*;
@@ -16,6 +18,7 @@ import static java.lang.System.*;
 import static java.util.Arrays.*;
 
 public class NitmProxyConfig {
+
     private ProxyMode proxyMode;
 
     private String host;
@@ -34,6 +37,8 @@ public class NitmProxyConfig {
     private List<HttpListener> httpListeners;
     private TrustManager trustManager;
 
+    private List<ProtocolDetector> detectors;
+
     // Default values
     public NitmProxyConfig() {
         proxyMode = ProxyMode.HTTP;
@@ -49,6 +54,7 @@ public class NitmProxyConfig {
         maxContentLength = 1024 * 1024;
 
         httpListeners = new ArrayList<>();
+        detectors = Collections.singletonList(Http1ProtocolDetector.INSTANCE);
     }
 
     public ProxyMode getProxyMode() {
@@ -145,6 +151,14 @@ public class NitmProxyConfig {
 
     public void setHttpListeners(List<HttpListener> httpListeners) {
         this.httpListeners = httpListeners;
+    }
+
+    public List<ProtocolDetector> getDetectors() {
+        return detectors;
+    }
+
+    public void setDetectors(List<ProtocolDetector> detectors) {
+        this.detectors = detectors;
     }
 
     @Override

--- a/src/main/java/com/github/chhsiao90/nitmproxy/Protocols.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/Protocols.java
@@ -1,0 +1,12 @@
+package com.github.chhsiao90.nitmproxy;
+
+public class Protocols {
+
+    public static final String HTTP_1 = "http";
+    public static final String HTTP_2 = "h2";
+    public static final String FORWARD = "forward";
+    public static final String UNKNOWN = "unknown";
+
+    private Protocols() {
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/TlsContext.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/TlsContext.java
@@ -1,7 +1,6 @@
 package com.github.chhsiao90.nitmproxy;
 
 import com.github.chhsiao90.nitmproxy.exception.TlsException;
-import io.netty.handler.ssl.ApplicationProtocolNames;
 import io.netty.util.concurrent.Promise;
 
 import java.util.List;
@@ -66,7 +65,6 @@ public class TlsContext {
 
     public void disableTls() {
         enabled = false;
-        protocols.setSuccess(singletonList(ApplicationProtocolNames.HTTP_1_1));
-        protocol.setSuccess(ApplicationProtocolNames.HTTP_1_1);
+        protocols.setSuccess(emptyList());
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardHandler.java
@@ -15,6 +15,6 @@ public class ForwardHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, ByteBuf byteBuf) throws Exception {
-        outboundChannel.writeAndFlush(byteBuf);
+        outboundChannel.writeAndFlush(byteBuf.retain());
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/ProtocolDetector.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/ProtocolDetector.java
@@ -1,0 +1,11 @@
+package com.github.chhsiao90.nitmproxy.handler.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Optional;
+
+public interface ProtocolDetector {
+
+    Optional<String> detect(ByteBuf msg);
+
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/ProtocolSelectHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/ProtocolSelectHandler.java
@@ -1,0 +1,44 @@
+package com.github.chhsiao90.nitmproxy.handler.protocol;
+
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
+import com.github.chhsiao90.nitmproxy.Protocols;
+import com.github.chhsiao90.nitmproxy.exception.NitmProxyException;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.ByteToMessageDecoder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+public class ProtocolSelectHandler extends ByteToMessageDecoder {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ProtocolSelectHandler.class);
+
+    private final ConnectionContext connectionContext;
+
+    public ProtocolSelectHandler(ConnectionContext connectionContext) {
+        this.connectionContext = connectionContext;
+    }
+
+    @Override
+    protected void decode(ChannelHandlerContext ctx, ByteBuf in, List<Object> out) throws Exception {
+        String protocol = connectionContext
+                .config()
+                .getDetectors()
+                .stream()
+                .flatMap(detector -> detector.detect(in).map(Stream::of).orElse(Stream.empty()))
+                .findFirst()
+                .orElse(Protocols.FORWARD);
+        connectionContext.tlsCtx().protocolPromise().setSuccess(protocol);
+
+        try {
+            ctx.pipeline().addAfter(ctx.name(), null, connectionContext.provider().frontendHandler(protocol));
+            ctx.pipeline().remove(this);
+        } catch (NitmProxyException e) {
+            LOGGER.error("{} : Unsupported protocol", connectionContext);
+            ctx.close();
+        }
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1FrontendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1FrontendHandler.java
@@ -3,6 +3,7 @@ package com.github.chhsiao90.nitmproxy.handler.protocol.http1;
 import com.github.chhsiao90.nitmproxy.Address;
 import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import com.github.chhsiao90.nitmproxy.NitmProxyMaster;
+import com.github.chhsiao90.nitmproxy.Protocols;
 import com.github.chhsiao90.nitmproxy.enums.ProxyMode;
 import com.github.chhsiao90.nitmproxy.event.OutboundChannelClosedEvent;
 import com.github.chhsiao90.nitmproxy.http.HttpUrl;
@@ -129,6 +130,7 @@ public class Http1FrontendHandler extends SimpleChannelInboundHandler<FullHttpRe
         });
         if (!connectionContext.tlsCtx().isNegotiated()) {
             connectionContext.tlsCtx().disableTls();
+            connectionContext.tlsCtx().protocolPromise().setSuccess(Protocols.HTTP_1);
         }
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1ProtocolDetector.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1ProtocolDetector.java
@@ -1,0 +1,43 @@
+package com.github.chhsiao90.nitmproxy.handler.protocol.http1;
+
+import com.github.chhsiao90.nitmproxy.Protocols;
+import com.github.chhsiao90.nitmproxy.handler.protocol.ProtocolDetector;
+import io.netty.buffer.ByteBuf;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public class Http1ProtocolDetector implements ProtocolDetector {
+
+    private static final int MAX_READ_BYTES = 100;
+    private static final Pattern HTTP_FIRST_LINE = Pattern.compile("[A-Z]+\\s\\S+\\sHTTP/1\\.1");
+
+    public static final Http1ProtocolDetector INSTANCE = new Http1ProtocolDetector();
+
+    @Override
+    public Optional<String> detect(ByteBuf msg) {
+        int readBytes = Math.min(MAX_READ_BYTES, msg.readableBytes());
+        if (readBytes == 0) {
+            return Optional.empty();
+        }
+        byte[] bytes = new byte[readBytes];
+        for (int pos = 0; pos < readBytes; pos++) {
+            bytes[pos] = msg.getByte(pos);
+            if (bytes[pos] == '\r') {
+                bytes = Arrays.copyOf(bytes, pos);
+                break;
+            }
+        }
+        String line = new String(bytes);
+        if (HTTP_FIRST_LINE.matcher(line).matches()) {
+            return Optional.of(Protocols.HTTP_1);
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public String toString() {
+        return Protocols.HTTP_1;
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
@@ -2,6 +2,8 @@ package com.github.chhsiao90.nitmproxy.handler.protocol.tls;
 
 import com.github.chhsiao90.nitmproxy.Address;
 import com.github.chhsiao90.nitmproxy.ConnectionContext;
+import com.github.chhsiao90.nitmproxy.Protocols;
+import com.github.chhsiao90.nitmproxy.exception.NitmProxyException;
 import com.github.chhsiao90.nitmproxy.tls.TlsUtil;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufAllocator;
@@ -58,8 +60,8 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
     @Override
     public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
         LOGGER.error(format("%s : exceptionCaught with %s",
-                            connectionContext, cause.getMessage()),
-                     cause);
+                connectionContext, cause.getMessage()),
+                cause);
         ctx.close();
     }
 
@@ -67,19 +69,20 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
         return TlsUtil.ctxForServer(connectionContext).newHandler(alloc);
     }
 
-    private void configHttp1(ChannelHandlerContext ctx) {
-        ctx.pipeline().replace(this, null, connectionContext.provider().http1FrontendHandler());
-    }
-
-    private void configHttp2(ChannelHandlerContext ctx) {
-        ctx.pipeline().replace(this, null, connectionContext.provider().http2FrontendHandler());
+    private void configureProtocol(ChannelHandlerContext ctx, String protocol) {
+        try {
+            ctx.pipeline().replace(this, null, connectionContext.provider().frontendHandler(protocol));
+        } catch (NitmProxyException e) {
+            LOGGER.error("{} : Unsupported protocol", connectionContext);
+            ctx.close();
+        }
     }
 
     private class DetectSslHandler extends SslClientHelloHandler<Boolean> {
 
         private final ChannelHandlerContext tlsCtx;
 
-        private DetectSslHandler(ChannelHandlerContext tlsCtx) {
+        public DetectSslHandler(ChannelHandlerContext tlsCtx) {
             this.tlsCtx = tlsCtx;
         }
 
@@ -97,13 +100,31 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
                 ctx.close();
             } else if (!future.getNow()) {
                 connectionContext.tlsCtx().disableTls();
-                configHttp1(tlsCtx);
+                ctx.pipeline().addAfter(ctx.name(), null, connectionContext.provider().protocolSelectHandler());
+                ctx.pipeline().remove(tlsCtx.name());
                 ctx.pipeline().remove(SniExtractorHandler.class);
                 ctx.pipeline().remove(AlpnNegotiateHandler.class);
                 ctx.pipeline().remove(ctx.name());
             } else {
                 ctx.pipeline().remove(ctx.name());
             }
+        }
+    }
+
+    private class SniExtractorHandler extends AbstractSniHandler<Object> {
+
+        @Override
+        protected Future<Object> lookup(ChannelHandlerContext ctx, String hostname) {
+            LOGGER.debug("Client SNI lookup with {}", hostname);
+            if (hostname != null) {
+                connectionContext.withServerAddr(new Address(hostname, connectionContext.getServerAddr().getPort()));
+            }
+            return ctx.executor().newSucceededFuture(null);
+        }
+
+        @Override
+        protected void onLookupComplete(ChannelHandlerContext ctx, String hostname, Future<Object> future) {
+            ctx.pipeline().remove(this);
         }
     }
 
@@ -145,23 +166,6 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
         }
     }
 
-    private class SniExtractorHandler extends AbstractSniHandler<Object> {
-
-        @Override
-        protected Future<Object> lookup(ChannelHandlerContext ctx, String hostname) {
-            LOGGER.debug("Client SNI lookup with {}", hostname);
-            if (hostname != null) {
-                connectionContext.withServerAddr(new Address(hostname, connectionContext.getServerAddr().getPort()));
-            }
-            return ctx.executor().newSucceededFuture(null);
-        }
-
-        @Override
-        protected void onLookupComplete(ChannelHandlerContext ctx, String hostname, Future<Object> future) {
-            ctx.pipeline().remove(this);
-        }
-    }
-
     private class AlpnHandler extends ApplicationProtocolNegotiationHandler {
 
         private ChannelHandlerContext tlsCtx;
@@ -174,11 +178,11 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
         @Override
         protected void configurePipeline(ChannelHandlerContext ctx, String protocol) {
             if (ApplicationProtocolNames.HTTP_1_1.equals(protocol)) {
-                configHttp1(tlsCtx);
+                configureProtocol(tlsCtx, Protocols.HTTP_1);
             } else if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
-                configHttp2(tlsCtx);
+                configureProtocol(tlsCtx, Protocols.HTTP_2);
             } else {
-                throw new IllegalStateException("unknown protocol: " + protocol);
+                configureProtocol(tlsCtx, Protocols.FORWARD);
             }
         }
     }


### PR DESCRIPTION
Currently, only http protocol supports network traffic interception.
Network traffic is forward to other channel directly for other
protocols.

Resolved: #8