### PR TITLE
logger for the forwarding handler

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/HandlerProvider.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/HandlerProvider.java
@@ -2,6 +2,7 @@ package com.github.chhsiao90.nitmproxy;
 
 import com.github.chhsiao90.nitmproxy.exception.NitmProxyException;
 import com.github.chhsiao90.nitmproxy.handler.ForwardBackendHandler;
+import com.github.chhsiao90.nitmproxy.handler.ForwardEventHandler;
 import com.github.chhsiao90.nitmproxy.handler.ForwardFrontendHandler;
 import com.github.chhsiao90.nitmproxy.handler.protocol.ProtocolSelectHandler;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http1.Http1BackendHandler;
@@ -90,5 +91,9 @@ public class HandlerProvider {
 
     public ChannelHandler forwardBackendHandler() {
         return new ForwardBackendHandler(context);
+    }
+
+    public ChannelHandler forwardEventHandler() {
+        return new ForwardEventHandler(master, context);
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -3,6 +3,7 @@ package com.github.chhsiao90.nitmproxy;
 import com.github.chhsiao90.nitmproxy.enums.ProxyMode;
 import com.github.chhsiao90.nitmproxy.handler.protocol.ProtocolDetector;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http1.Http1ProtocolDetector;
+import com.github.chhsiao90.nitmproxy.listener.ForwardListener;
 import com.github.chhsiao90.nitmproxy.listener.HttpListener;
 import com.google.common.base.Joiner;
 
@@ -35,6 +36,7 @@ public class NitmProxyConfig {
     private int maxContentLength;
 
     private List<HttpListener> httpListeners;
+    private List<ForwardListener> forwardListeners;
     private TrustManager trustManager;
 
     private List<ProtocolDetector> detectors;
@@ -54,6 +56,7 @@ public class NitmProxyConfig {
         maxContentLength = 1024 * 1024;
 
         httpListeners = new ArrayList<>();
+        forwardListeners = new ArrayList<>();
         detectors = Collections.singletonList(Http1ProtocolDetector.INSTANCE);
     }
 
@@ -151,6 +154,14 @@ public class NitmProxyConfig {
 
     public void setHttpListeners(List<HttpListener> httpListeners) {
         this.httpListeners = httpListeners;
+    }
+
+    public List<ForwardListener> getForwardListeners() {
+        return forwardListeners;
+    }
+
+    public void setForwardListeners(List<ForwardListener> forwardListeners) {
+        this.forwardListeners = forwardListeners;
     }
 
     public List<ProtocolDetector> getDetectors() {

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyMaster.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyMaster.java
@@ -1,6 +1,7 @@
 package com.github.chhsiao90.nitmproxy;
 
 import com.github.chhsiao90.nitmproxy.channel.BackendChannelBootstrap;
+import com.github.chhsiao90.nitmproxy.listener.ForwardListener;
 import com.github.chhsiao90.nitmproxy.listener.HttpListener;
 import com.github.chhsiao90.nitmproxy.listener.NitmProxyListenerManager;
 import com.github.chhsiao90.nitmproxy.tls.CertManager;
@@ -19,7 +20,8 @@ public class NitmProxyMaster {
                            BackendChannelBootstrap backendChannelBootstrap) {
         this.config = config;
         this.backendChannelBootstrap = backendChannelBootstrap;
-        this.nitmProxyListenerManager = new NitmProxyListenerManager(config.getHttpListeners());
+        this.nitmProxyListenerManager = new NitmProxyListenerManager(
+                config.getHttpListeners(), config.getForwardListeners());
         this.certManager = new CertManager(config);
     }
 
@@ -32,6 +34,10 @@ public class NitmProxyMaster {
     }
 
     public HttpListener httpEventListener() {
+        return nitmProxyListenerManager;
+    }
+
+    public ForwardListener forwardEventListener() {
         return nitmProxyListenerManager;
     }
 

--- a/src/main/java/com/github/chhsiao90/nitmproxy/event/ForwardEvent.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/event/ForwardEvent.java
@@ -1,0 +1,116 @@
+package com.github.chhsiao90.nitmproxy.event;
+
+import com.github.chhsiao90.nitmproxy.Address;
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
+import io.netty.buffer.ByteBuf;
+
+public class ForwardEvent {
+    private Address client;
+    private Address server;
+
+    private long requestBodySize;
+    private long requestTime;
+
+    // response
+    private long responseBodySize;
+    private long responseTime;
+
+    private long timeSpent;
+
+    private ForwardEvent(Builder builder) {
+        client = builder.client;
+        server = builder.server;
+
+        requestBodySize = builder.requestBodySize;
+        requestTime = builder.requestTime;
+
+        responseBodySize = builder.responseBodySize;
+        responseTime = builder.responseTime;
+
+        timeSpent = builder.responseTime - builder.requestTime;
+    }
+
+    public static Builder builder(ConnectionContext ctx) {
+        return new Builder(ctx);
+    }
+
+    public Address getClient() {
+        return client;
+    }
+
+    public Address getServer() {
+        return server;
+    }
+
+    public long getRequestBodySize() {
+        return requestBodySize;
+    }
+
+    public long getRequestTime() {
+        return requestTime;
+    }
+
+    public long getResponseBodySize() {
+        return responseBodySize;
+    }
+
+    public long getResponseTime() {
+        return responseTime;
+    }
+
+    public long getTimeSpent() {
+        return timeSpent;
+    }
+
+    public static class Builder {
+        private Address client;
+        private Address server;
+
+        // request
+        private long requestBodySize;
+        private long requestTime;
+
+        // response
+        private long responseBodySize;
+        private long responseTime;
+
+        private Builder(ConnectionContext ctx) {
+            client = ctx.getClientAddr();
+            server = ctx.getServerAddr();
+        }
+
+        public Builder requestBodySize(long requestBodySize) {
+            this.requestBodySize = requestBodySize;
+            return this;
+        }
+
+        public Builder addRequestBodySize(long delta) {
+            this.requestBodySize += delta;
+            return this;
+        }
+
+        public Builder requestTime(long requestTime) {
+            this.requestTime = requestTime;
+            return this;
+        }
+
+        public Builder responseBodySize(long responseBodySize) {
+            this.responseBodySize = responseBodySize;
+            return this;
+        }
+
+        public Builder addResponseBodySize(long delta) {
+            this.responseBodySize += delta;
+            return this;
+        }
+
+        public Builder responseTime(long responseTime) {
+            this.responseTime = responseTime;
+            return this;
+        }
+
+        public ForwardEvent build() {
+            return new ForwardEvent(this);
+        }
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardEventHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardEventHandler.java
@@ -1,0 +1,68 @@
+package com.github.chhsiao90.nitmproxy.handler;
+
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
+import com.github.chhsiao90.nitmproxy.NitmProxyMaster;
+import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
+import com.github.chhsiao90.nitmproxy.listener.ForwardListener;
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelDuplexHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+
+import static java.lang.System.currentTimeMillis;
+
+public class ForwardEventHandler extends ChannelDuplexHandler {
+
+    private ForwardListener listener;
+    private ConnectionContext connectionContext;
+
+    private long requestTime;
+    private long requestBytes;
+
+    /**
+     * Create new instance of http1 event handler.
+     *
+     * @param master            the master
+     * @param connectionContext the connection context
+     */
+    public ForwardEventHandler(
+            NitmProxyMaster master,
+            ConnectionContext connectionContext) {
+        this.listener = master.forwardEventListener();
+        this.connectionContext = connectionContext;
+    }
+
+    @Override
+    public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
+            throws Exception {
+        ByteBuf byteBuf = (ByteBuf) msg;
+        listener.onForwardResponse(byteBuf);
+        long responseTime = currentTimeMillis();
+        ForwardEvent forwardEvent = ForwardEvent.builder(connectionContext)
+                .requestBodySize(requestBytes)
+                .requestTime(requestTime)
+                .responseTime(responseTime)
+                .responseBodySize(byteBuf.readableBytes())
+                .build();
+        try {
+            listener.onForwardEvent(forwardEvent);
+        } finally {
+            requestTime = 0;
+        }
+        super.write(ctx, msg, promise);
+    }
+
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        ByteBuf byteBuf = (ByteBuf) msg;
+        listener.onForwardRequest(byteBuf);
+        requestBytes = byteBuf.readableBytes();
+        requestTime = currentTimeMillis();
+        super.channelRead(ctx, msg);
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        ctx.fireChannelInactive();
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardFrontendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardFrontendHandler.java
@@ -2,16 +2,22 @@ package com.github.chhsiao90.nitmproxy.handler;
 
 import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class ForwardFrontendHandler extends SimpleChannelInboundHandler<ByteBuf> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ForwardFrontendHandler.class);
 
     private ConnectionContext connectionContext;
+
+    private List<ChannelHandler> addedHandlers = new ArrayList<>(3);
 
     public ForwardFrontendHandler(ConnectionContext connectionContext) {
         super();
@@ -21,6 +27,14 @@ public class ForwardFrontendHandler extends SimpleChannelInboundHandler<ByteBuf>
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
         LOGGER.debug("{} : handlerAdded", connectionContext);
+        addedHandlers.add(connectionContext.provider().forwardEventHandler());
+        addedHandlers.forEach(handler -> ctx.pipeline().addBefore(ctx.name(), null, handler));
+    }
+
+    @Override
+    public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+        LOGGER.debug("{} : handlerRemoved", connectionContext);
+        addedHandlers.forEach(handler -> ctx.pipeline().remove(handler));
     }
 
     @Override

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardEventLogger.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardEventLogger.java
@@ -1,0 +1,32 @@
+package com.github.chhsiao90.nitmproxy.listener;
+
+import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ForwardEventLogger implements ForwardListener {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ForwardEventLogger.class);
+
+    @Override
+    public void onForwardEvent(ForwardEvent event) {
+        LOGGER.info("{} {} {} {} {}",
+                event.getTimeSpent(),
+                event.getServer(),
+                event.getClient(),
+                event.getRequestBodySize(),
+                event.getResponseBodySize());
+    }
+
+    @Override
+    public void onForwardRequest(ByteBuf byteBuf) {
+        LOGGER.debug("{}", ByteBufUtil.hexDump(byteBuf));
+    }
+
+    @Override
+    public void onForwardResponse(ByteBuf byteBuf) {
+        LOGGER.debug("{}", ByteBufUtil.hexDump(byteBuf));
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardListener.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardListener.java
@@ -1,0 +1,17 @@
+package com.github.chhsiao90.nitmproxy.listener;
+
+import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
+import io.netty.buffer.ByteBuf;
+
+public interface ForwardListener {
+
+    default void onForwardEvent(ForwardEvent forwardEvent) {
+    }
+
+    default void onForwardRequest(ByteBuf byteBuf) {
+    }
+
+    default void onForwardResponse(ByteBuf byteBuf) {
+    }
+
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/NitmProxyListenerManager.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/NitmProxyListenerManager.java
@@ -1,7 +1,9 @@
 package com.github.chhsiao90.nitmproxy.listener;
 
+import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
 import com.github.chhsiao90.nitmproxy.event.HttpEvent;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http2.Http2FrameWrapper;
+import io.netty.buffer.ByteBuf;
 import io.netty.handler.codec.http.HttpContent;
 import io.netty.handler.codec.http.HttpRequest;
 import io.netty.handler.codec.http.HttpResponse;
@@ -9,13 +11,17 @@ import io.netty.handler.codec.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
 
-public class NitmProxyListenerManager implements HttpListener {
+public class NitmProxyListenerManager implements HttpListener, ForwardListener {
 
-    private List<HttpListener> httpListeners = new ArrayList<>();
+    private final List<HttpListener> httpListeners = new ArrayList<>();
+    private final List<ForwardListener> forwardListeners = new ArrayList<>();
 
-    public NitmProxyListenerManager(List<HttpListener> listeners) {
-        httpListeners.add(new HttpEventLogger());
-        httpListeners.addAll(listeners);
+    public NitmProxyListenerManager(List<HttpListener> httpListeners,
+                                    List<ForwardListener> forwardListeners) {
+        this.httpListeners.add(new HttpEventLogger());
+        this.httpListeners.addAll(httpListeners);
+        this.forwardListeners.add(new ForwardEventLogger());
+        this.forwardListeners.addAll(forwardListeners);
     }
 
     @Override
@@ -51,5 +57,20 @@ public class NitmProxyListenerManager implements HttpListener {
     @Override
     public void onHttp2ResponseFrame(Http2FrameWrapper<?> frame) {
         httpListeners.forEach(listener -> listener.onHttp2ResponseFrame(frame));
+    }
+
+    @Override
+    public void onForwardEvent(ForwardEvent event) {
+        forwardListeners.forEach(listener -> listener.onForwardEvent(event));
+    }
+
+    @Override
+    public void onForwardRequest(ByteBuf byteBuf) {
+        forwardListeners.forEach(listener -> listener.onForwardRequest(byteBuf));
+    }
+
+    @Override
+    public void onForwardResponse(ByteBuf byteBuf) {
+        forwardListeners.forEach(listener -> listener.onForwardResponse(byteBuf));
     }
 }


### PR DESCRIPTION
I added a logger for logging all binary related data from the forwarding handler.
A general problem I currently see with the handlers, is that is difficult to assemble related data. E.g. the HTTP request and response data is logged with a different method than the HTTP event having the metadata. I have used the same pattern for the forwarding logger, but how would the data merged again together to have a PCAP file in wireshark?