### PR TITLE
Added proxy status and onStart and onStop event listener

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxy.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxy.java
@@ -26,7 +26,7 @@ public class NitmProxy {
 
     private NioEventLoopGroup bossGroup;
     private NioEventLoopGroup workerGroup;
-
+    private NitmProxyStatus status = NitmProxyStatus.NOTCONFIGURED;
     public NitmProxy(NitmProxyConfig config) {
         this.config = config;
     }
@@ -49,10 +49,17 @@ public class NitmProxy {
             LOGGER.info("nitmproxy is listening at {}:{}",
                               config.getHost(), config.getPort());
 
+            status = NitmProxyStatus.STARTED;
+
+            if (config.getStatusListener() != null) {
+                config.getStatusListener().onStart();
+            }
+
             channel.closeFuture().sync();
         } finally {
             bossGroup.shutdownGracefully();
             workerGroup.shutdownGracefully();
+            status = NitmProxyStatus.STOPPED;
         }
     }
 
@@ -63,6 +70,16 @@ public class NitmProxy {
         if (workerGroup != null) {
             workerGroup.shutdownGracefully();
         }
+
+        status = NitmProxyStatus.STOPPED;
+
+        if (config.getStatusListener() != null) {
+            config.getStatusListener().onStop();
+        }
+    }
+
+    public NitmProxyStatus getStatus() {
+        return status;
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -34,6 +34,7 @@ public class NitmProxyConfig {
 
     private int maxContentLength;
 
+    private NitmProxyStatusListener statusListener;
     private List<HttpListener> httpListeners;
     private TrustManager trustManager;
 
@@ -159,6 +160,14 @@ public class NitmProxyConfig {
 
     public void setDetectors(List<ProtocolDetector> detectors) {
         this.detectors = detectors;
+    }
+
+    public NitmProxyStatusListener getStatusListener() {
+        return statusListener;
+    }
+
+    public void setStatusListener(NitmProxyStatusListener statusListener) {
+        this.statusListener = statusListener;
     }
 
     @Override

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatus.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatus.java
@@ -1,0 +1,7 @@
+package com.github.chhsiao90.nitmproxy;
+
+public enum NitmProxyStatus {
+    STARTED,
+    STOPPED,
+    NOTCONFIGURED
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatusListener.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatusListener.java
@@ -1,6 +1,7 @@
 package com.github.chhsiao90.nitmproxy;
 
 public interface NitmProxyStatusListener {
+
     default void onStart() {
 
     }
@@ -8,4 +9,5 @@ public interface NitmProxyStatusListener {
     default void onStop() {
 
     }
+
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatusListener.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatusListener.java
@@ -1,0 +1,11 @@
+package com.github.chhsiao90.nitmproxy;
+
+public interface NitmProxyStatusListener {
+    default void onStart() {
+
+    }
+
+    default void onStop() {
+
+    }
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatusListener.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyStatusListener.java
@@ -3,11 +3,8 @@ package com.github.chhsiao90.nitmproxy;
 public interface NitmProxyStatusListener {
 
     default void onStart() {
-
     }
 
     default void onStop() {
-
     }
-
 }


### PR DESCRIPTION
When the proxy is run through an async process, we need notifications when the server has completely started and stopped along with a status. 