### PR TITLE
Tries to fallback to http/1.1 if possible

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import static io.netty.handler.ssl.ApplicationProtocolNames.*;
 import static java.lang.String.*;
 
 public class TlsBackendHandler extends ChannelDuplexHandler {
@@ -133,14 +134,25 @@ public class TlsBackendHandler extends ChannelDuplexHandler {
         SslHandler sslHandler = sslHandler(ctx.alloc());
         ctx.pipeline()
             .addBefore(ctx.name(), null, sslHandler)
-            .addBefore(ctx.name(), null, new AlpnHandler(ctx));
+            .addBefore(ctx.name(), null, new AlpnHandler(ctx, getFallbackProtocol()));
+    }
+
+    private String getFallbackProtocol() {
+        if (connectionContext.tlsCtx().isNegotiated()) {
+            return connectionContext.tlsCtx().protocol();
+        }
+        if (connectionContext.tlsCtx().protocolsPromise().isSuccess()
+            && !connectionContext.tlsCtx().protocols().contains(HTTP_1_1)) {
+            return HTTP_1_1;
+        }
+        return Protocols.FORWARD;
     }
 
     private class AlpnHandler extends ApplicationProtocolNegotiationHandler {
         private ChannelHandlerContext tlsCtx;
 
-        private AlpnHandler(ChannelHandlerContext tlsCtx) {
-            super(Protocols.FORWARD);
+        private AlpnHandler(ChannelHandlerContext tlsCtx, String fallbackProtocol) {
+            super(fallbackProtocol);
             this.tlsCtx = tlsCtx;
         }
 

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
@@ -142,7 +142,7 @@ public class TlsBackendHandler extends ChannelDuplexHandler {
             return connectionContext.tlsCtx().protocol();
         }
         if (connectionContext.tlsCtx().protocolsPromise().isSuccess()
-            && !connectionContext.tlsCtx().protocols().contains(HTTP_1_1)) {
+            && connectionContext.tlsCtx().protocols().contains(HTTP_1_1)) {
             return HTTP_1_1;
         }
         return Protocols.FORWARD;


### PR DESCRIPTION
Previously, we fallback to forward handler if alpn extension is not
provided by the backend. We can fallback to http/1.1 if http alpn
extension was provided by the client.

Resolved: #52