### PR TITLE
On ALPN failure we should always try to detect the protocol first before resorting to the forward handler

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/HandlerProvider.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/HandlerProvider.java
@@ -36,6 +36,8 @@ public class HandlerProvider {
             return http2FrontendHandler();
         } else if (protocol.equals(Protocols.FORWARD)) {
             return forwardFrontendHandler();
+        } else if (protocol.equals(Protocols.UNKNOWN)) {
+            return unknownFrontendHandler();
         } else {
             throw new NitmProxyException("Unsupported protocol");
         }
@@ -48,6 +50,8 @@ public class HandlerProvider {
             return http2BackendHandler();
         } else if (protocol.equals(Protocols.FORWARD)) {
             return forwardBackendHandler();
+        } else if (protocol.equals(Protocols.UNKNOWN)) {
+            return unknownBackendHandler();
         } else {
             throw new NitmProxyException("Unsupported protocol");
         }
@@ -95,5 +99,13 @@ public class HandlerProvider {
 
     public ChannelHandler forwardEventHandler() {
         return new ForwardEventHandler(master, context);
+    }
+
+    public ChannelHandler unknownFrontendHandler() {
+        return new ProtocolSelectHandler(context);
+    }
+
+    public ChannelHandler unknownBackendHandler() {
+        return new ProtocolSelectHandler(context);
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -3,6 +3,7 @@ package com.github.chhsiao90.nitmproxy;
 import com.github.chhsiao90.nitmproxy.enums.ProxyMode;
 import com.github.chhsiao90.nitmproxy.handler.protocol.ProtocolDetector;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http1.Http1ProtocolDetector;
+import com.github.chhsiao90.nitmproxy.handler.protocol.http2.Http2ProtocolDetector;
 import com.github.chhsiao90.nitmproxy.listener.ForwardListener;
 import com.github.chhsiao90.nitmproxy.listener.HttpListener;
 import com.google.common.base.Joiner;
@@ -13,6 +14,7 @@ import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManager;
 import java.security.Provider;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -62,7 +64,8 @@ public class NitmProxyConfig {
 
         httpListeners = new ArrayList<>();
         forwardListeners = new ArrayList<>();
-        detectors = Collections.singletonList(Http1ProtocolDetector.INSTANCE);
+        detectors = Collections.unmodifiableList(
+                Arrays.asList(Http1ProtocolDetector.INSTANCE, Http2ProtocolDetector.INSTANCE));
     }
 
     public void init() {

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/AbstractHttpProtocolDetector.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/AbstractHttpProtocolDetector.java
@@ -1,0 +1,42 @@
+package com.github.chhsiao90.nitmproxy.handler.protocol;
+
+import io.netty.buffer.ByteBuf;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+public abstract class AbstractHttpProtocolDetector implements ProtocolDetector {
+
+    private final int maxBytes;
+    private final Pattern pattern;
+
+    public AbstractHttpProtocolDetector(int maxBytes, Pattern pattern) {
+        this.pattern = pattern;
+        this.maxBytes = maxBytes;
+    }
+
+    @Override
+    public Optional<String> detect(ByteBuf msg) {
+        int readBytes = Math.min(maxBytes, msg.readableBytes());
+        if (readBytes == 0) {
+            return Optional.empty();
+        }
+        byte[] bytes = new byte[readBytes];
+        for (int pos = 0; pos < readBytes; pos++) {
+            bytes[pos] = msg.getByte(pos);
+            if (bytes[pos] == '\r') {
+                bytes = Arrays.copyOf(bytes, pos);
+                break;
+            }
+        }
+        String line = new String(bytes);
+        if (pattern.matcher(line).matches()) {
+            return Optional.of(toString());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public abstract String toString();
+}

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http2/Http2ProtocolDetector.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http2/Http2ProtocolDetector.java
@@ -1,4 +1,4 @@
-package com.github.chhsiao90.nitmproxy.handler.protocol.http1;
+package com.github.chhsiao90.nitmproxy.handler.protocol.http2;
 
 import com.github.chhsiao90.nitmproxy.Protocols;
 import com.github.chhsiao90.nitmproxy.handler.protocol.AbstractHttpProtocolDetector;
@@ -7,14 +7,14 @@ import io.netty.buffer.ByteBuf;
 import java.util.Optional;
 import java.util.regex.Pattern;
 
-public class Http1ProtocolDetector extends AbstractHttpProtocolDetector {
+public class Http2ProtocolDetector extends AbstractHttpProtocolDetector {
 
     private static final int MAX_READ_BYTES = 100;
-    private static final Pattern HTTP_FIRST_LINE = Pattern.compile("[A-Z]+\\s\\S+\\sHTTP/1\\.1");
+    private static final Pattern HTTP_FIRST_LINE = Pattern.compile("[A-Z]+\\s\\S+\\sHTTP/2\\.0");
 
-    public static final Http1ProtocolDetector INSTANCE = new Http1ProtocolDetector();
+    public static final Http2ProtocolDetector INSTANCE = new Http2ProtocolDetector();
 
-    public Http1ProtocolDetector() {
+    public Http2ProtocolDetector() {
         super(MAX_READ_BYTES, HTTP_FIRST_LINE);
     }
 
@@ -25,7 +25,6 @@ public class Http1ProtocolDetector extends AbstractHttpProtocolDetector {
 
     @Override
     public String toString() {
-        return Protocols.HTTP_1;
+        return Protocols.HTTP_2;
     }
 }
-

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsBackendHandler.java
@@ -167,7 +167,7 @@ public class TlsBackendHandler extends ChannelDuplexHandler {
             } else if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
                 configureProtocol(tlsCtx, Protocols.HTTP_2);
             } else {
-                configureProtocol(tlsCtx, Protocols.FORWARD);
+                configureProtocol(tlsCtx, Protocols.UNKNOWN);
             }
         }
 

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/tls/TlsFrontendHandler.java
@@ -218,7 +218,7 @@ public class TlsFrontendHandler extends ChannelDuplexHandler {
             } else if (ApplicationProtocolNames.HTTP_2.equals(protocol)) {
                 configureProtocol(tlsCtx, Protocols.HTTP_2);
             } else {
-                configureProtocol(tlsCtx, Protocols.FORWARD);
+                configureProtocol(tlsCtx, Protocols.UNKNOWN);
             }
         }
     }


### PR DESCRIPTION
Currently on ALPN negotiation failure, we move to the forward handler. The change tries to detect the HTTP1 and HTTP2 protocols on both the backend and the frontend before resorting to the forward handler. 