### PR TITLE
adding context to handler

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardEventHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/ForwardEventHandler.java
@@ -36,7 +36,7 @@ public class ForwardEventHandler extends ChannelDuplexHandler {
     public void write(ChannelHandlerContext ctx, Object msg, ChannelPromise promise)
             throws Exception {
         ByteBuf byteBuf = (ByteBuf) msg;
-        listener.onForwardResponse(byteBuf);
+        listener.onForwardResponse(connectionContext, byteBuf);
         long responseTime = currentTimeMillis();
         ForwardEvent forwardEvent = ForwardEvent.builder(connectionContext)
                 .requestBodySize(requestBytes)
@@ -45,7 +45,7 @@ public class ForwardEventHandler extends ChannelDuplexHandler {
                 .responseBodySize(byteBuf.readableBytes())
                 .build();
         try {
-            listener.onForwardEvent(forwardEvent);
+            listener.onForwardEvent(connectionContext, forwardEvent);
         } finally {
             requestTime = 0;
         }
@@ -55,7 +55,7 @@ public class ForwardEventHandler extends ChannelDuplexHandler {
     @Override
     public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
         ByteBuf byteBuf = (ByteBuf) msg;
-        listener.onForwardRequest(byteBuf);
+        listener.onForwardRequest(connectionContext, byteBuf);
         requestBytes = byteBuf.readableBytes();
         requestTime = currentTimeMillis();
         super.channelRead(ctx, msg);

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1EventHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1EventHandler.java
@@ -54,13 +54,13 @@ public class Http1EventHandler extends ChannelDuplexHandler {
         if (msg instanceof HttpResponse) {
             checkState(!requests.isEmpty(), "request is empty");
             checkState(response == null, "response is not null");
-            listener.onHttp1Response((HttpResponse) msg);
+            listener.onHttp1Response(connectionContext, (HttpResponse) msg);
             responseBytes = new AtomicLong();
             response = retain((HttpResponse) msg);
         }
         if (msg instanceof HttpContent) {
             HttpContent httpContent = (HttpContent) msg;
-            listener.onHttp1ResponseData((HttpContent) msg);
+            listener.onHttp1ResponseData(connectionContext, (HttpContent) msg);
             responseBytes.addAndGet(httpContent.content().readableBytes());
         }
         if (msg instanceof LastHttpContent) {
@@ -102,7 +102,7 @@ public class Http1EventHandler extends ChannelDuplexHandler {
         }
 
         FullHttpRequest request = (FullHttpRequest) msg;
-        Optional<FullHttpResponse> response =  listener.onHttp1Request((FullHttpRequest) msg);
+        Optional<FullHttpResponse> response =  listener.onHttp1Request(connectionContext, (FullHttpRequest) msg);
         if (response.isPresent()) {
             try {
                 sendResponse(ctx, request, response.get());

--- a/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http2/Http2EventHandler.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/handler/protocol/http2/Http2EventHandler.java
@@ -85,7 +85,7 @@ public class Http2EventHandler extends ChannelDuplexHandler {
             return;
         }
 
-        Optional<Http2FramesWrapper> responseOptional = listener.onHttp2Request(fullRequest.get());
+        Optional<Http2FramesWrapper> responseOptional = listener.onHttp2Request(connectionContext, fullRequest.get());
         if (!responseOptional.isPresent()) {
             fullRequest.get().getAllFrames().forEach(ctx::fireChannelRead);
             return;

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardEventLogger.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardEventLogger.java
@@ -1,5 +1,6 @@
 package com.github.chhsiao90.nitmproxy.listener;
 
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
@@ -11,7 +12,7 @@ public class ForwardEventLogger implements ForwardListener {
     private static final Logger LOGGER = LoggerFactory.getLogger(ForwardEventLogger.class);
 
     @Override
-    public void onForwardEvent(ForwardEvent event) {
+    public void onForwardEvent(ConnectionContext connectionContext, ForwardEvent event) {
         LOGGER.info("{} {} {} {} {}",
                 event.getTimeSpent(),
                 event.getServer(),
@@ -21,12 +22,12 @@ public class ForwardEventLogger implements ForwardListener {
     }
 
     @Override
-    public void onForwardRequest(ByteBuf byteBuf) {
+    public void onForwardRequest(ConnectionContext connectionContext, ByteBuf byteBuf) {
         LOGGER.debug("{}", ByteBufUtil.hexDump(byteBuf));
     }
 
     @Override
-    public void onForwardResponse(ByteBuf byteBuf) {
+    public void onForwardResponse(ConnectionContext connectionContext, ByteBuf byteBuf) {
         LOGGER.debug("{}", ByteBufUtil.hexDump(byteBuf));
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardListener.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/ForwardListener.java
@@ -1,17 +1,18 @@
 package com.github.chhsiao90.nitmproxy.listener;
 
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
 import io.netty.buffer.ByteBuf;
 
 public interface ForwardListener {
 
-    default void onForwardEvent(ForwardEvent forwardEvent) {
+    default void onForwardEvent(ConnectionContext connectionContext, ForwardEvent forwardEvent) {
     }
 
-    default void onForwardRequest(ByteBuf byteBuf) {
+    default void onForwardRequest(ConnectionContext connectionContext, ByteBuf byteBuf) {
     }
 
-    default void onForwardResponse(ByteBuf byteBuf) {
+    default void onForwardResponse(ConnectionContext connectionContext, ByteBuf byteBuf) {
     }
 
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/HttpListener.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/HttpListener.java
@@ -1,5 +1,6 @@
 package com.github.chhsiao90.nitmproxy.listener;
 
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import com.github.chhsiao90.nitmproxy.event.HttpEvent;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http2.Http2DataFrameWrapper;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http2.Http2FrameWrapper;
@@ -18,23 +19,24 @@ public interface HttpListener {
     default void onHttpEvent(HttpEvent event) {
     }
 
-    default Optional<FullHttpResponse> onHttp1Request(FullHttpRequest request) {
+    default Optional<FullHttpResponse> onHttp1Request(ConnectionContext connectionContext, FullHttpRequest request) {
         return Optional.empty();
     }
 
-    default void onHttp1Response(HttpResponse response) {
+    default void onHttp1Response(ConnectionContext connectionContext, HttpResponse response) {
     }
 
-    default void onHttp1ResponseData(HttpContent data) {
+    default void onHttp1ResponseData(ConnectionContext connectionContext, HttpContent data) {
     }
 
-    default Optional<Http2FramesWrapper> onHttp2Request(Http2FramesWrapper request) {
+    default Optional<Http2FramesWrapper> onHttp2Request(ConnectionContext connectionContext,
+                                                        Http2FramesWrapper request) {
         return Optional.empty();
     }
 
-    default void onHttp2Response(Http2FrameWrapper<Http2HeadersFrame> frame) {
+    default void onHttp2Response(ConnectionContext connectionContext, Http2FrameWrapper<Http2HeadersFrame> frame) {
     }
 
-    default void onHttp2ResponseData(Http2DataFrameWrapper frame) {
+    default void onHttp2ResponseData(ConnectionContext connectionContext, Http2DataFrameWrapper frame) {
     }
 }

--- a/src/main/java/com/github/chhsiao90/nitmproxy/listener/NitmProxyListenerManager.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/listener/NitmProxyListenerManager.java
@@ -1,5 +1,6 @@
 package com.github.chhsiao90.nitmproxy.listener;
 
+import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import com.github.chhsiao90.nitmproxy.event.ForwardEvent;
 import com.github.chhsiao90.nitmproxy.event.HttpEvent;
 import com.github.chhsiao90.nitmproxy.handler.protocol.http2.Http2DataFrameWrapper;
@@ -37,54 +38,56 @@ public class NitmProxyListenerManager implements HttpListener, ForwardListener {
     }
 
     @Override
-    public Optional<FullHttpResponse> onHttp1Request(FullHttpRequest request) {
-        Function<HttpListener, Stream<FullHttpResponse>> apply = listener -> listener.onHttp1Request(request)
+    public Optional<FullHttpResponse> onHttp1Request(ConnectionContext connectionContext, FullHttpRequest request) {
+        Function<HttpListener, Stream<FullHttpResponse>> apply = listener -> listener.onHttp1Request(connectionContext,
+                request)
                 .map(Stream::of)
                 .orElse(Stream.empty());
         return httpListeners.stream().flatMap(apply).findFirst();
     }
 
     @Override
-    public void onHttp1Response(HttpResponse response) {
-        httpListeners.forEach(listener -> listener.onHttp1Response(response));
+    public void onHttp1Response(ConnectionContext connectionContext, HttpResponse response) {
+        httpListeners.forEach(listener -> listener.onHttp1Response(connectionContext, response));
     }
 
     @Override
-    public void onHttp1ResponseData(HttpContent data) {
-        httpListeners.forEach(listener -> listener.onHttp1ResponseData(data));
+    public void onHttp1ResponseData(ConnectionContext connectionContext, HttpContent data) {
+        httpListeners.forEach(listener -> listener.onHttp1ResponseData(connectionContext, data));
     }
 
     @Override
-    public Optional<Http2FramesWrapper> onHttp2Request(Http2FramesWrapper request) {
+    public Optional<Http2FramesWrapper> onHttp2Request(ConnectionContext connectionContext,
+                                                       Http2FramesWrapper request) {
         Function<HttpListener, Stream<Http2FramesWrapper>> apply = listener -> listener
-                .onHttp2Request(request)
+                .onHttp2Request(connectionContext, request)
                 .map(Stream::of)
                 .orElse(Stream.empty());
         return httpListeners.stream().flatMap(apply).findFirst();
     }
 
     @Override
-    public void onHttp2Response(Http2FrameWrapper<Http2HeadersFrame> frame) {
-        httpListeners.forEach(listener -> listener.onHttp2Response(frame));
+    public void onHttp2Response(ConnectionContext connectionContext, Http2FrameWrapper<Http2HeadersFrame> frame) {
+        httpListeners.forEach(listener -> listener.onHttp2Response(connectionContext, frame));
     }
 
     @Override
-    public void onHttp2ResponseData(Http2DataFrameWrapper frame) {
-        httpListeners.forEach(listener -> listener.onHttp2ResponseData(frame));
+    public void onHttp2ResponseData(ConnectionContext connectionContext, Http2DataFrameWrapper frame) {
+        httpListeners.forEach(listener -> listener.onHttp2ResponseData(connectionContext, frame));
     }
 
     @Override
-    public void onForwardEvent(ForwardEvent event) {
-        forwardListeners.forEach(listener -> listener.onForwardEvent(event));
+    public void onForwardEvent(ConnectionContext connectionContext, ForwardEvent event) {
+        forwardListeners.forEach(listener -> listener.onForwardEvent(connectionContext, event));
     }
 
     @Override
-    public void onForwardRequest(ByteBuf byteBuf) {
-        forwardListeners.forEach(listener -> listener.onForwardRequest(byteBuf));
+    public void onForwardRequest(ConnectionContext connectionContext, ByteBuf byteBuf) {
+        forwardListeners.forEach(listener -> listener.onForwardRequest(connectionContext, byteBuf));
     }
 
     @Override
-    public void onForwardResponse(ByteBuf byteBuf) {
-        forwardListeners.forEach(listener -> listener.onForwardResponse(byteBuf));
+    public void onForwardResponse(ConnectionContext connectionContext, ByteBuf byteBuf) {
+        forwardListeners.forEach(listener -> listener.onForwardResponse(connectionContext, byteBuf));
     }
 }

--- a/src/test/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1EventHandlerTest.java
+++ b/src/test/java/com/github/chhsiao90/nitmproxy/handler/protocol/http1/Http1EventHandlerTest.java
@@ -56,7 +56,7 @@ public class Http1EventHandlerTest {
 
     @Test
     public void shouldLogWithFullResponse() {
-        when(listener.onHttp1Request(any())).thenReturn(Optional.empty());
+        when(listener.onHttp1Request(any(), any())).thenReturn(Optional.empty());
 
         assertTrue(channel.writeInbound(defaultRequest()));
         assertTrue(channel.writeOutbound(defaultResponse("Hello Nitmproxy")));
@@ -80,7 +80,7 @@ public class Http1EventHandlerTest {
 
     @Test
     public void shouldLogWithResponseAndContent() {
-        when(listener.onHttp1Request(any())).thenReturn(Optional.empty());
+        when(listener.onHttp1Request(any(), any())).thenReturn(Optional.empty());
 
         HttpResponse response = new DefaultHttpResponse(HTTP_1_1, OK);
         response.headers()
@@ -110,7 +110,7 @@ public class Http1EventHandlerTest {
 
     @Test
     public void shouldInterceptWithResponse() {
-        when(listener.onHttp1Request(any())).thenReturn(Optional.of(defaultResponse("Hello Nitmproxy")));
+        when(listener.onHttp1Request(any(), any())).thenReturn(Optional.of(defaultResponse("Hello Nitmproxy")));
 
         assertFalse(channel.writeInbound(defaultRequest()));
         assertChannel(channel)

--- a/src/test/java/com/github/chhsiao90/nitmproxy/handler/protocol/http2/Http2EventHandlerTest.java
+++ b/src/test/java/com/github/chhsiao90/nitmproxy/handler/protocol/http2/Http2EventHandlerTest.java
@@ -52,7 +52,7 @@ public class Http2EventHandlerTest {
 
     @Test
     public void shouldSendRequestAfterRequestEnded() {
-        when(listener.onHttp2Request(any())).thenReturn(Optional.empty());
+        when(listener.onHttp2Request(any(), any())).thenReturn(Optional.empty());
         List<Http2FrameWrapper<?>> requestFrames = Http2FramesWrapper
                 .builder(1)
                 .request(textRequest(HttpVersion.HTTP_1_1, POST, "localhost", "/", "Hello nitmproxy"))
@@ -70,7 +70,7 @@ public class Http2EventHandlerTest {
 
     @Test
     public void shouldLogWithFullResponse() {
-        when(listener.onHttp2Request(any())).thenReturn(Optional.empty());
+        when(listener.onHttp2Request(any(), any())).thenReturn(Optional.empty());
 
         Http2FramesWrapper
                 .builder(1)
@@ -104,7 +104,7 @@ public class Http2EventHandlerTest {
 
     @Test
     public void shouldInterceptWithResponse() {
-        when(listener.onHttp2Request(any())).thenReturn(Optional.of(Http2FramesWrapper
+        when(listener.onHttp2Request(any(), any())).thenReturn(Optional.of(Http2FramesWrapper
                 .builder(1)
                 .response(defaultResponse("Hello nitmproxy"))
                 .build()));


### PR DESCRIPTION
For using the log handlers to create complete network dumps for wireshark the connection context is necessary to have source and destination IPs and ports.