### PR TITLE
Backend channel handler

### DIFF
--- a/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/NitmProxyConfig.java
@@ -56,7 +56,9 @@ public class NitmProxyConfig {
     /**
      * Handler for getting the created channel of the backend, i.e. the channel connecting to the actual target.
      * <p>
-     *     E.g. in Android this can be used to used to protect the channel <a href="https://developer.android.com/reference/android/net/VpnService#protect(int)">VpnService#protect(int)</a>
+     *     E.g. in Android this can be used to used to protect the channel
+     *     <a href="https://developer.android.com/reference/android/net/VpnService#protect(int)">
+     *         VpnService#protect(int)</a>
      * </p>
      */
     private Consumer<Channel> onConnectHandler;

--- a/src/main/java/com/github/chhsiao90/nitmproxy/channel/BackendChannelBootstrap.java
+++ b/src/main/java/com/github/chhsiao90/nitmproxy/channel/BackendChannelBootstrap.java
@@ -4,7 +4,11 @@ import com.github.chhsiao90.nitmproxy.ConnectionContext;
 import com.github.chhsiao90.nitmproxy.NitmProxyMaster;
 
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.*;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelFutureListener;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.Channel;
 
 public class BackendChannelBootstrap {
     public ChannelFuture connect(ChannelHandlerContext fromCtx,
@@ -27,6 +31,5 @@ public class BackendChannelBootstrap {
         }
         return channelFuture;
     }
-
 
 }


### PR DESCRIPTION
This relates to https://github.com/chhsiao90/nitmproxy/issues/82. Under Android a channel must be "protected", i.e. marked as being already handled by a VPNService, otherwise a loop would result also redirecting the network traffic to the VPNService again. I created this hook to be able to get access for this and possibly other requirements in a generic way. Under Android `setOnConnectHandler` would be called and from the Netty `Channel` the channel id could be cast to a socket integer. 

Questions: 
a) Is the logic really called first after the channel is created, so that any VpnService cannot handle the channel again?
b) Is this the best approach?